### PR TITLE
Bug Fixes

### DIFF
--- a/lib/history.js
+++ b/lib/history.js
@@ -232,7 +232,7 @@ History.prototype._save = function(block)
 
 	if(this._items.length > MAX_HISTORY)
 	{
-		this._items.pop();
+		this._items.splice(0,1);
 	}
 }
 

--- a/lib/history.js
+++ b/lib/history.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 var d3 = require('d3');
 
-var MAX_HISTORY = 2000;
+var MAX_HISTORY = process.env.MAX_HISTORY || 2000;
 
 var MAX_PEER_PROPAGATION = 40;
 var MIN_PROPAGATION_RANGE = 0;

--- a/lib/history.js
+++ b/lib/history.js
@@ -264,9 +264,12 @@ History.prototype.search = function(number)
 
 History.prototype.prevMaxBlock = function(number)
 {
-	var index = _.findIndex(this._items, function (item) {
-		return item.height < number;
-	});
+	var index = -1;
+	for(let i=0; i<this._items.length; i++) {
+		if (this._items[i].height < number) {
+      index = i;
+		}
+	}
 
 	if(index < 0)
 		return false;

--- a/lib/history.js
+++ b/lib/history.js
@@ -276,14 +276,14 @@ History.prototype.prevMaxBlock = function(number)
 
 History.prototype.bestBlock = function()
 {
-	return _.max(this._items, 'height');
+	return _.maxBy(this._items, 'height');
 }
 
 History.prototype.bestBlockNumber = function()
 {
 	var best = this.bestBlock();
 
-	if( !_.isUndefined(best.height) )
+	if( !_.isUndefined(best) && !_.isUndefined(best.height) )
 		return best.height;
 
 	return 0;
@@ -291,14 +291,14 @@ History.prototype.bestBlockNumber = function()
 
 History.prototype.worstBlock = function()
 {
-	return _.min(this._items, 'height');
+	return _.minBy(this._items, 'height');
 }
 
 History.prototype.worstBlockNumber = function(trusted)
 {
 	var worst = this.worstBlock();
 
-	if( !_.isUndefined(worst.height) )
+	if( !_.isUndefined(worst) && !_.isUndefined(worst.height) )
 		return worst.height;
 
 	return 0;
@@ -335,8 +335,7 @@ History.prototype.getNodePropagation = function(id)
 				}
 			}
 		})
-		.reverse()
-		.value();
+		.reverse();
 
 	return propagation;
 }

--- a/src/js/defaultConfig.js
+++ b/src/js/defaultConfig.js
@@ -1,2 +1,2 @@
-var networkName = 'Ethereum';
+var networkName = process.env.NETWORK_NAME || 'Ethereum';
 var faviconPath = '/favicon.ico';


### PR DESCRIPTION
For the graphs rendered observation was that the content didn't change after a point. After MAX_HISTORY blocks were persisted in memory, looked like the data of the most recent block was being swapped with the data of current block. Leaving data of the previous section of the graph un-touched. 

Made the following fixes in an attempt to achieve desired behaviour. 

1. In `_save` method, made changes to swap the oldest block out of the `items` array instead of the most recent one. 

2. In `previousBlock` method,  made changes to return the immediate previous block and not the first one from the `items` array.

3. Added an optional env var to change the default value of max items (blocks) for which data would be persisted in memory

4. Server used to crash as per issue already reported https://github.com/goerli/ethstats-server/issues/17. Took fix from an existing PR https://github.com/goerli/ethstats-server/pull/19

5. added an optional env var NETWORK_NAME